### PR TITLE
Changed Q.info.url to location.href, because during user registration…

### DIFF
--- a/web/js/Communities.js
+++ b/web/js/Communities.js
@@ -1448,7 +1448,7 @@ function _updateSlots(slotNames, onActivate) {
 		return;
 	}
 
-	Q.loadUrl(Q.info.url, {
+	Q.loadUrl(location.href, {
 		slotNames: slotNames,
 		loadExtras: 'all',
 		ignoreDialogs: true,


### PR DESCRIPTION
… param Q.info.url changed to Streams/register and hence second request to this url will lead to register new user.